### PR TITLE
Add bulma-extensions-rails to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ This repository provide a simple access to all extensions for Bulma.
 
 Each extensions is a git submodule.
 
+## Documentation & Demo
 
-Documentation & Demo
----
 You can find the Documentation and a demo [here](https://wikiki.github.io/)
-
 
 # How to clone this repository
 
@@ -27,8 +25,8 @@ or
 git clone --recursive https://github.com/Wikiki/bulma-extensions.git
 ```
 
-Related projects
---
-* AxureRP is a great Library for Bulma and all the extensions: [Bulma.io-axure
-](https://github.com/Code-Mine-Development/Bulma.io-axure)
+## Related projects
+
+* AxureRP is a great Library for Bulma and all the extensions: [Bulma.io-axure](https://github.com/Code-Mine-Development/Bulma.io-axure)
 * Preset for Bulma scaffolding on new Laravel 5.5.x project. [Laravel 5.5.x Front-end Preset For Bulma](https://github.com/laravel-frontend-presets/bulma)
+* Bulma extensions rails is a ruby on rails wrapper for bulma extensions. [Bulma-extensions-rails](https://github.com/dhmgroup/bulma-extensions-rails)


### PR DESCRIPTION
I just made a rails wrapper for bulma extensions as bulma-extension-rails. It's on [github](https://github.com/dhmgroup/bulma-extensions-rails) and [rubygems.org](https://rubygems.org/gems/bulma-extensions-rails)